### PR TITLE
5.03.00044 Crosspoints

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="39">
-	<version>5.03.00043</version>
+	<version>5.03.00044</version>
 	<author><![CDATA[Courseplay.devTeam]]></author>
 	<title>
 		<br>CoursePlay 5</br>


### PR DESCRIPTION
Cross points fixed. On merge courses two methods are used to choose best pair.

Vehicle total direction change plays major role. If new pair results in 10 degree or better angle then that is used as best match. This could safely be increased to 20 or so, depending on preference of the final result. 

Still if angle is slightly worse (within 10 degrees, tunable), but merge points are closer then angle is sacrificed and closer cross points are used. Do not recommend to increase by much as that can result in car overshooting the best turns a little bit. 

If there are few cross points placed with relative care it will give best results.  

Will work fine if you spam cross points at intersections while driving straight, but will basically always result in straight turn angle in the middle of intersection - no turn radius.

May work a little funny if you spam cross points  while drunk-driving - this can result in very good angles that are separated by large distance (up to 50 m) and 10 degrees leeway is no longer enough to prefer closer points. For this reason really recommend to reduce wpDistMax from 50m to 30. Even lower if cross points will be spammed.